### PR TITLE
[ Feature ] Uploading casters' avatars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 core-build/
 cache/
 .DS_Store
+frontend/img/*
+!frontend/img/.gitkeep

--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -1,5 +1,7 @@
-document.querySelector('#add-caster-form').addEventListener('submit', (e) => {
+document.querySelector('#add-caster-form').addEventListener('submit', async (e) => {
   e.preventDefault()
+
+  const upload = await updateFile(document.querySelector('#logo').files[0], document.querySelector('#name').value)
 
   window.LPTE.emit({
     meta: {
@@ -7,11 +9,13 @@ document.querySelector('#add-caster-form').addEventListener('submit', (e) => {
       type: 'add-caster',
       version: 1
     },
+    logo: upload.data.name,
     name: document.querySelector('#name').value,
     platform: document.querySelector('#platform').value,
     handle: document.querySelector('#handle').value
   })
 
+  document.querySelector('#logo').value = null
   document.querySelector('#name').value = ''
   document.querySelector('#platform').value = 'Twitch'
   document.querySelector('#handle').value = ''
@@ -157,6 +161,13 @@ function displayCasterTable(data) {
   data.caster.forEach((c) => {
     const row = document.createElement('tr')
 
+    const logoTd = document.createElement('td')
+    const logoImg = document.createElement('img')
+    logoImg.src = `/pages/op-module-caster/img/${c.logo}`
+    logoImg.style.height = '2.3rem'
+    logoTd.appendChild(logoImg)
+    row.appendChild(logoTd)
+
     const nameTd = document.createElement('td')
     nameTd.innerText = c.name
     row.appendChild(nameTd)
@@ -206,6 +217,25 @@ function displayCasterSelects(data) {
     casterThree.options.add(new Option(c.name, c.id), [i + 1])
     casterFour.options.add(new Option(c.name, c.id), [i + 1])
   })
+}
+
+async function updateFile(file, name) {
+  if(!file) return
+
+  const ext = file.name.split('.').pop()
+
+  const form = new FormData()
+  form.append('file', file, `module-caster/frontend/img/${name}.${ext}`)
+  form.append('path', 'module-caster/frontend/img')
+
+  const response = await fetch('/upload', {
+    method: 'POST',
+    body: form
+  })
+
+  const json = await response.json()
+
+  return json
 }
 
 window.LPTE.onready(() => {

--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -162,10 +162,7 @@ function displayCasterTable(data) {
     row.appendChild(nameTd)
 
     const platformTd = document.createElement('td')
-    platformTd.innerHTML =
-      c.platform === 'Twitch'
-        ? '<i class="fab fa-twitch"></i>'
-        : '<i class="fab fa-twitter"></i>'
+    platformTd.innerHTML = `<i class="fab fa-${c.platform.toLowerCase()}"></i>`
     row.appendChild(platformTd)
 
     const handleTd = document.createElement('td')

--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -9,13 +9,14 @@ document.querySelector('#add-caster-form').addEventListener('submit', async (e) 
       type: 'add-caster',
       version: 1
     },
-    logo: upload.data.name,
+    logo: upload?.data.name,
     name: document.querySelector('#name').value,
     platform: document.querySelector('#platform').value,
     handle: document.querySelector('#handle').value
   })
 
   document.querySelector('#logo').value = null
+  document.querySelector('.custom-file-label').textContent = 'Choose file'
   document.querySelector('#name').value = ''
   document.querySelector('#platform').value = 'Twitch'
   document.querySelector('#handle').value = ''

--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -135,6 +135,10 @@ async function initUi() {
   displayCasterSelects(casterData)
 
   displayData(data)
+
+  document.querySelector('#logo').addEventListener('change', (e) => {
+    document.querySelector('.custom-file-label').textContent = document.querySelector('#logo').files[0].name
+  })
 }
 
 function displayData(data) {

--- a/frontend/gfx/gfx.css
+++ b/frontend/gfx/gfx.css
@@ -50,6 +50,8 @@ body {
   border-radius: 50%;
   aspect-ratio: 1;
   transform: translateX(-25%);
+  object-fit: contain;
+  background: var(--background-color);
 }
 
 .caster-box .text {

--- a/frontend/gfx/gfx.css
+++ b/frontend/gfx/gfx.css
@@ -46,12 +46,10 @@ body {
 .caster-box .logo {
   position: relative;
   z-index: 5;
-  border: 2px solid black;
   border-radius: 50%;
   aspect-ratio: 1;
   transform: translateX(-25%);
   object-fit: contain;
-  background: var(--background-color);
 }
 
 .caster-box .text {

--- a/frontend/gfx/gfx.css
+++ b/frontend/gfx/gfx.css
@@ -46,13 +46,16 @@ body {
 .caster-box .logo {
   position: relative;
   z-index: 5;
+  border: 2px solid black;
+  border-radius: 50%;
+  aspect-ratio: 1;
   transform: translateX(-25%);
 }
 
 .caster-box .text {
   position: relative;
   z-index: 5;
-  margin-left: -25px;
+  margin-left: -20px;
 }
 
 #caster-two {
@@ -67,7 +70,7 @@ body {
 }
 
 #caster-two .text {
-  margin-right: -25px;
+  margin-right: -20px;
 }
 
 .name {

--- a/frontend/gfx/gfx.js
+++ b/frontend/gfx/gfx.js
@@ -36,12 +36,18 @@ function displayCaster(data) {
 
   if (!data.casterSets[set] || data.casterSets[set].length <= 0) return
 
+  casterOneLogo.addEventListener('error', (e) => {
+    casterOneLogo.src = '/pages/op-plugin-theming/active/logo.png'
+  }, { once: true })
   casterOneLogo.src = `/pages/op-module-caster/img/${data.casterSets[set][0].logo}`
   casterOneName.innerHTML = data.casterSets[set][0].name
   casterOneSocial.appendChild(
     getSocial(data.casterSets[set][0].platform, data.casterSets[set][0].handle)
     )
-
+  
+  casterTwoLogo.addEventListener('error', (e) => {
+    casterTwoLogo.src = '/pages/op-plugin-theming/active/logo.png'
+  }, { once: true })
   casterTwoLogo.src = `/pages/op-module-caster/img/${data.casterSets[set][1].logo}`
   casterTwoName.innerHTML = data.casterSets[set][1].name
   casterTwoSocial.appendChild(

--- a/frontend/gfx/gfx.js
+++ b/frontend/gfx/gfx.js
@@ -39,6 +39,7 @@ function displayCaster(data) {
   casterOneLogo.addEventListener('error', (e) => {
     casterOneLogo.style.visibility = 'hidden'
   })
+  casterOneLogo.style.visibility = ''
   casterOneLogo.src = `/pages/op-module-caster/img/${data.casterSets[set][0].logo}`
   casterOneName.innerHTML = data.casterSets[set][0].name
   casterOneSocial.appendChild(
@@ -48,6 +49,7 @@ function displayCaster(data) {
   casterTwoLogo.addEventListener('error', (e) => {
     casterTwoLogo.style.visibility = 'hidden'
   })
+  casterTwoLogo.style.visibility = ''
   casterTwoLogo.src = `/pages/op-module-caster/img/${data.casterSets[set][1].logo}`
   casterTwoName.innerHTML = data.casterSets[set][1].name
   casterTwoSocial.appendChild(

--- a/frontend/gfx/gfx.js
+++ b/frontend/gfx/gfx.js
@@ -7,15 +7,19 @@ const set = params.set || 1
 const caster = params.caster
 
 const casterOne = document.querySelector('#caster-one')
+const casterOneLogo = casterOne.querySelector('.logo')
 const casterOneName = casterOne.querySelector('.name')
 const casterOneSocial = casterOne.querySelector('.social')
 const casterTwo = document.querySelector('#caster-two')
+const casterTwoLogo = casterTwo.querySelector('.logo')
 const casterTwoName = casterTwo.querySelector('.name')
 const casterTwoSocial = casterTwo.querySelector('.social')
 
 function displayCaster(data) {
+  casterOneLogo.src = ''
   casterOneName.innerHTML = ''
   casterOneSocial.innerHTML = ''
+  casterTwoLogo.src = ''
   casterTwoName.innerHTML = ''
   casterTwoSocial.innerHTML = ''
 
@@ -32,11 +36,19 @@ function displayCaster(data) {
 
   if (!data.casterSets[set] || data.casterSets[set].length <= 0) return
 
+  casterOneLogo.addEventListener('error', (e) => {
+    casterOneLogo.style.visibility = 'hidden'
+  })
+  casterOneLogo.src = `/pages/op-module-caster/img/${data.casterSets[set][0].logo}`
   casterOneName.innerHTML = data.casterSets[set][0].name
   casterOneSocial.appendChild(
     getSocial(data.casterSets[set][0].platform, data.casterSets[set][0].handle)
-  )
-
+    )
+  
+  casterTwoLogo.addEventListener('error', (e) => {
+    casterTwoLogo.style.visibility = 'hidden'
+  })
+  casterTwoLogo.src = `/pages/op-module-caster/img/${data.casterSets[set][1].logo}`
   casterTwoName.innerHTML = data.casterSets[set][1].name
   casterTwoSocial.appendChild(
     getSocial(data.casterSets[set][1].platform, data.casterSets[set][1].handle)

--- a/frontend/gfx/gfx.js
+++ b/frontend/gfx/gfx.js
@@ -46,13 +46,16 @@ function displayCaster(data) {
 function getSocial(platform, handle) {
   const span = document.createElement('span')
 
-  const icon =
-    platform === 'Twitch'
-      ? '<i class="fab fa-twitch"></i>'
-      : '<i class="fab fa-twitter"></i>'
+  const icon =`<i class="fab fa-${platform.toLowerCase()}"></i>`
   span.innerHTML += icon
 
-  handle = platform === 'Twitch' ? `twitch.tv/${handle}` : `@${handle}`
+  switch(platform) {
+    case 'Twitch':
+      handle = `twitch.tv/${handle}`
+      break;
+    default:
+      handle = `@${handle}`
+  }
   span.innerHTML += handle
 
   return span

--- a/frontend/gfx/gfx.js
+++ b/frontend/gfx/gfx.js
@@ -67,8 +67,10 @@ function getSocial(platform, handle) {
     case 'Twitch':
       handle = `twitch.tv/${handle}`
       break;
-    default:
+    case 'X-Twitter':
+    case 'Discord':
       handle = `@${handle}`
+      break;
   }
   span.innerHTML += handle
 

--- a/frontend/gfx/gfx.js
+++ b/frontend/gfx/gfx.js
@@ -36,20 +36,12 @@ function displayCaster(data) {
 
   if (!data.casterSets[set] || data.casterSets[set].length <= 0) return
 
-  casterOneLogo.addEventListener('error', (e) => {
-    casterOneLogo.style.visibility = 'hidden'
-  })
-  casterOneLogo.style.visibility = ''
   casterOneLogo.src = `/pages/op-module-caster/img/${data.casterSets[set][0].logo}`
   casterOneName.innerHTML = data.casterSets[set][0].name
   casterOneSocial.appendChild(
     getSocial(data.casterSets[set][0].platform, data.casterSets[set][0].handle)
     )
-  
-  casterTwoLogo.addEventListener('error', (e) => {
-    casterTwoLogo.style.visibility = 'hidden'
-  })
-  casterTwoLogo.style.visibility = ''
+
   casterTwoLogo.src = `/pages/op-module-caster/img/${data.casterSets[set][1].logo}`
   casterTwoName.innerHTML = data.casterSets[set][1].name
   casterTwoSocial.appendChild(

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -165,7 +165,9 @@
         aria-describedby="Platform"
       >
         <option>Twitch</option>
-        <option>Twitter</option>
+        <option>X-Twitter</option>
+        <option>Instagram</option>
+        <option>Discord</option>
       </select>
     </div>
     <div class="form-group w-50">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -134,6 +134,7 @@
 <table class="table mb-3 mt-5">
   <thead>
     <tr>
+      <th scope="col">Logo</th>
       <th scope="col">Name</th>
       <th scope="col">Platform</th>
       <th scope="col">Handle</th>
@@ -144,8 +145,20 @@
 </table>
 
 <form id="add-caster-form">
-  <div class="d-flex">
-    <div class="form-group w-50 mr-3">
+  <div class="d-flex" style="gap: 1rem">
+    <div class="form-group w-25">
+      <label for="logo">Logo</label>
+      <div class="custom-file">
+        <input
+          type="file"
+          class="custom-file-input"
+          id="logo"
+          accept="image/*"
+        />
+        <label class="custom-file-label" for="logo">Choose file</label>
+      </div>
+    </div>
+    <div class="form-group w-50">
       <label for="name">Name</label>
       <input
         type="text"
@@ -156,7 +169,7 @@
         placeholder="Name"
       />
     </div>
-    <div class="form-group w-25 mr-3">
+    <div class="form-group w-25">
       <label for="platform">Social Platform</label>
       <select
         class="form-control"

--- a/plugin.ts
+++ b/plugin.ts
@@ -125,6 +125,7 @@ module.exports = async (ctx: PluginContext) => {
       },
       collection: 'caster',
       data: {
+        logo: e.logo,
         name: e.name,
         platform: e.platform,
         handle: e.handle


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
There was no option to upload casters' avatars.

**Describe the solution you'd like**
Displaying custom caster avatar next to their name instead of a logo from a theme. I reused some code from `Teams` module.

**Describe alternatives you've considered**
Manually changing source code to point to avatars.

**Additional context**
I also enhanced the look of the `img` to make it a circle
![image](https://github.com/rcv-prod-toolkit/module-caster/assets/46965900/5f93136d-f358-4a9b-84d9-51c0b863612f)
![image](https://github.com/rcv-prod-toolkit/module-caster/assets/46965900/a0e9906f-71ac-458b-b617-086e05d36f5d)

**Important**
I added and updated platforms to use font awesome icons so in the future more could be added. **_Font Awesome_ kit needs an update then because actual version does not support new `X-Twitter` icon**
![image](https://github.com/rcv-prod-toolkit/module-caster/assets/46965900/9bb7d9ae-c28d-494e-8211-5eca1597475d)
I think those platforms would fit as well:
- **Twitch**
- **X (Twitter)**
- *Instagram*
- *Discord*
- YouTube
- TikTok
- Telegram
